### PR TITLE
READMEにDB設計を記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,57 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# データベース:chat-space
+
+## usersテーブル/by&nbsp;device
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|index: true, null:false, unique:true|
+|mail|string|null: false, unique: true|
+
+### Association
+- has_many :groups, through: :group_users
+- has_many :group_users
+- has_many :massages
+
+
+## messageテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user|references|foreign_key: true|
+|body|text|null: false|
+|image|string||
+|group|references|foreign_key: true|
+
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|index: true, null:false, unique:true|
+
+### Association
+
+has_many :users, through: :group_users
+has_many :messages
+has_many :group_users
+
+
+## users_groupテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user|references|index: true, foreign_key: true, null: false|
+|group|references|index: true, foreign_key: true, null: false|
+
+### Association
+- belongs_to :user
+- belongs_to :group


### PR DESCRIPTION
# What
課題アプリ『chat-space』のデータベース設計をREADMEに記述。

# Why
カリキュラムでは、データベース設計をREADMEに記述した後、それをメンターに審査してもらう必要があるから。