### PR TITLE
READMEにDB設計を記載（改訂版）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<<<<<<< Updated upstream
 # README
 
 This README would normally document whatever steps are necessary to get the
@@ -22,3 +23,58 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+=======
+# データベース:chat-space
+
+## usersテーブル/by&nbsp;device
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|index: true, null:false, unique:true|
+|mail|string|null: false, unique: true|
+
+### Association
+- has_many :groups, through: :groups_users
+- has_many :groups_users
+- has_many :massages
+
+
+## messageテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user|references|foreign_key: true|
+|body|text|null: false|
+|image|string||
+|group|references|foreign_key: true|
+
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|index: true, null:false, unique:true|
+
+### Association
+
+has_many :users, through: :group_users
+has_many :messages
+has_many :groups_users
+
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group|references|index: true, foreign_key: true, null: false|
+|user|references|index: true, foreign_key: true, null: false|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+>>>>>>> Stashed changes

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@
 
 ### Association
 
-has_many :users, through: :group_users
-has_many :messages
-has_many :groups_users
+- has_many :users, through: :group_users
+- has_many :messages
+- has_many :groups_users
 
 
 ## groups_usersテーブル

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ### Association
 - has_many :groups, through: :groups_users
 - has_many :groups_users
-- has_many :massages
+- has_many :messages
 
 
 ## messageテーブル

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |user|references|foreign_key: true|
-|body|text|null: false|
+|body|text||
 |image|string||
 |group|references|foreign_key: true|
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # データベース:chat-space
 
-## usersテーブル/by&nbsp;device
+## usersテーブル
 
 |Column|Type|Options|
 |------|----|-------|

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|user|references|foreign_key: true|
+|user|references|foreign_key: true, null: false|
 |body|text||
 |image|string||
 |group|references|foreign_key: true, null: false|

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 |user|references|foreign_key: true|
 |body|text||
 |image|string||
-|group|references|foreign_key: true|
+|group|references|foreign_key: true, null: false|
 
 
 ### Association

--- a/README.md
+++ b/README.md
@@ -1,29 +1,3 @@
-<<<<<<< Updated upstream
-# README
-
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
-=======
 # データベース:chat-space
 
 ## usersテーブル/by&nbsp;device
@@ -77,4 +51,3 @@ has_many :groups_users
 ### Association
 - belongs_to :user
 - belongs_to :group
->>>>>>> Stashed changes

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|group|references|index: true, foreign_key: true, null: false|
-|user|references|index: true, foreign_key: true, null: false|
+|group|references|foreign_key: true, null: false|
+|user|references|foreign_key: true, null: false|
 
 ### Association
 - belongs_to :user


### PR DESCRIPTION
# What
READMEにDB設計を、見出しやテーブルを使って見やすいREADMEを目指しながら、マークダウンで記述。テーブルのカラムと型、オプション、アソシエーションも記入済み。

# Why
READMEにDB設計をmasterブランチにマージする前に、メンターさんにチェックしてもらう必要があるから。